### PR TITLE
docs: add repository guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Repository Guidelines
+
+This project uses Turborepo with an `apps` and `packages` structure.
+
+## Development workflow
+- Commit messages should follow conventional commit format.
+- Always run `pnpm lint --fix` before committing. If the command fails due to missing dependencies, note the failure in the PR.
+- Add `// TODO(codex):` comments when leaving tasks for manual follow-up.
+- If tests run for more than 30 minutes without finishing, stop the run.
+- Create a Changesets changelog entry for each feature.
+- Open a draft PR per milestone and keep diffs under 400 lines.


### PR DESCRIPTION
## Summary
- document repository guidelines in AGENTS.md

## Testing
- `pnpm lint --fix` *(fails: no package manifest)*

------
https://chatgpt.com/codex/tasks/task_e_68496e9faf088329a771d2577f4747bc