### PR TITLE
Set up tsup for core package

### DIFF
--- a/.changeset/core-tsup-build.md
+++ b/.changeset/core-tsup-build.md
@@ -1,0 +1,5 @@
+---
+"@nano-codeblock/core": patch
+---
+
+Set up tsup build configuration and script.

--- a/nano-codeblock/packages/core/package.json
+++ b/nano-codeblock/packages/core/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@nano-codeblock/core",
   "version": "0.0.0",
+  "scripts": {
+    "build": "tsup"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/nano-codeblock/packages/core/tsup.config.ts
+++ b/nano-codeblock/packages/core/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+})

--- a/nano-codeblock/turbo.json
+++ b/nano-codeblock/turbo.json
@@ -5,7 +5,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "lint": {
       "dependsOn": ["^lint"]


### PR DESCRIPTION
## Summary
- configure `tsup` for `@nano-codeblock/core`
- wire the `build` script and Turbo outputs
- add a changeset for the build setup

## Testing
- `pnpm lint --fix` *(fails: ESLint couldn't find a config)*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6849828a4d5c832983d568648efc1c2f