### PR TITLE
Add theme enum and clipboard util to core

### DIFF
--- a/.changeset/core-theme-copy.md
+++ b/.changeset/core-theme-copy.md
@@ -1,0 +1,5 @@
+---
+"@nano-codeblock/core": minor
+---
+
+Add theme enumeration and clipboard utility with tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,11 @@
 # Repository Guidelines
 
-This project uses Turborepo with an `apps` and `packages` structure.
+This project uses Turborepo with an `apps` and `packages` structure. All Node commands should be run from the `nano-codeblock` directory.
 
 ## Development workflow
 - Commit messages should follow conventional commit format.
-- Always run `pnpm lint --fix` before committing. If the command fails due to missing dependencies, note the failure in the PR.
+- Always run `pnpm lint --fix` before committing. Run this command from the `nano-codeblock` directory. If the command fails due to missing dependencies, note the failure in the PR.
+- Run tests with `pnpm exec vitest run packages/core/src --run` from the `nano-codeblock` directory.
 - Add `// TODO(codex):` comments when leaving tasks for manual follow-up.
 - If tests run for more than 30 minutes without finishing, stop the run.
 - Create a Changesets changelog entry for each feature.

--- a/nano-codeblock/packages/core/src/copy.test.ts
+++ b/nano-codeblock/packages/core/src/copy.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from 'vitest';
+import { copyToClipboard } from './copy';
+
+describe('copyToClipboard', () => {
+  it('writes text to the clipboard', async () => {
+    const writeText = vi.fn();
+    (
+      globalThis as { navigator?: { clipboard: { writeText: (text: string) => Promise<void> } } }
+    ).navigator = {
+      clipboard: { writeText },
+    };
+
+    await copyToClipboard('foo');
+    expect(writeText).toHaveBeenCalledWith('foo');
+  });
+});

--- a/nano-codeblock/packages/core/src/copy.ts
+++ b/nano-codeblock/packages/core/src/copy.ts
@@ -1,0 +1,7 @@
+export async function copyToClipboard(text: string): Promise<void> {
+  if (typeof globalThis.navigator === 'undefined' || !globalThis.navigator.clipboard) {
+    return;
+  }
+
+  await globalThis.navigator.clipboard.writeText(text);
+}

--- a/nano-codeblock/packages/core/src/index.ts
+++ b/nano-codeblock/packages/core/src/index.ts
@@ -1,1 +1,3 @@
 export * from './highlight';
+export * from './theme';
+export * from './copy';

--- a/nano-codeblock/packages/core/src/theme.ts
+++ b/nano-codeblock/packages/core/src/theme.ts
@@ -1,0 +1,5 @@
+export enum Theme {
+  dracula = 'dracula',
+  github = 'github-dark',
+  light = 'one-light',
+}


### PR DESCRIPTION
## Summary
- add Theme enum for available themes
- add clipboard helper
- test clipboard helper
- export new utilities
- update AGENTS guidelines for linting and testing
- fix clipboard utility to handle non-browser environments

## Testing
- `pnpm lint --fix` (from `nano-codeblock`) ✅
- `pnpm exec vitest run packages/core/src --run` ✅

------
https://chatgpt.com/codex/tasks/task_e_684989fa0ca88329a0bd37cc8f1c1517