### PR TITLE
feat(core): add CSS themes

### DIFF
--- a/.changeset/core-themes-css.md
+++ b/.changeset/core-themes-css.md
@@ -1,0 +1,5 @@
+---
+"@nano-codeblock/core": minor
+---
+
+Add CSS themes with root variables and fade-in animation. The new `themes.css` file is shipped with the package.

--- a/nano-codeblock/packages/core/package.json
+++ b/nano-codeblock/packages/core/package.json
@@ -7,7 +7,10 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist",
+    "src/themes.css"
+  ],
   "dependencies": {
     "prismjs": "^1.29.0"
   }

--- a/nano-codeblock/packages/core/src/themes.css
+++ b/nano-codeblock/packages/core/src/themes.css
@@ -1,0 +1,52 @@
+:root {
+  --cb-background: #282a36;
+  --cb-foreground: #f8f8f2;
+  --cb-comment: #6272a4;
+  --cb-string: #f1fa8c;
+  --cb-keyword: #ff79c6;
+  --cb-function: #50fa7b;
+  --cb-punctuation: #f8f8f2;
+}
+
+.cb-theme-dracula {
+  --cb-background: #282a36;
+  --cb-foreground: #f8f8f2;
+  --cb-comment: #6272a4;
+  --cb-string: #f1fa8c;
+  --cb-keyword: #ff79c6;
+  --cb-function: #50fa7b;
+  --cb-punctuation: #f8f8f2;
+}
+
+.cb-theme-github {
+  --cb-background: #0d1117;
+  --cb-foreground: #c9d1d9;
+  --cb-comment: #8b949e;
+  --cb-string: #a5d6ff;
+  --cb-keyword: #ff7b72;
+  --cb-function: #d2a8ff;
+  --cb-punctuation: #c9d1d9;
+}
+
+.cb-theme-one-light {
+  --cb-background: #fafafa;
+  --cb-foreground: #383a42;
+  --cb-comment: #a0a1a7;
+  --cb-string: #50a14f;
+  --cb-keyword: #a626a4;
+  --cb-function: #4078f2;
+  --cb-punctuation: #383a42;
+}
+
+.cb-fade-in {
+  animation: cb-fade-in 0.2s ease-in-out;
+}
+
+@keyframes cb-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add `themes.css` with variables and theme classes
- bundle the css file with `@nano-codeblock/core`
- document the new themes in a changeset

## Testing
- `pnpm lint --fix` *(fails: Cannot find module '@eslint/js')*
- `pnpm exec vitest run packages/core/src --run` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498cd9e77883299b5e93b343ea32ab