### PR TITLE
feat: add react wrapper component

### DIFF
--- a/.changeset/react-wrapper-component.md
+++ b/.changeset/react-wrapper-component.md
@@ -1,0 +1,5 @@
+---
+"@nano-codeblock/react": minor
+---
+
+Add React wrapper component with highlight and clipboard support.

--- a/nano-codeblock/packages/react/package.json
+++ b/nano-codeblock/packages/react/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@nano-codeblock/react",
+  "version": "0.0.0",
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "@nano-codeblock/core": "workspace:*"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ]
+}

--- a/nano-codeblock/packages/react/src/CodeBlock.test.tsx
+++ b/nano-codeblock/packages/react/src/CodeBlock.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { CodeBlock } from './CodeBlock';
+import * as core from '@nano-codeblock/core';
+
+vi.mock('@nano-codeblock/core', async () => {
+  const actual = await vi.importActual<typeof core>('@nano-codeblock/core');
+  return { ...actual, copyToClipboard: vi.fn() };
+});
+
+describe('CodeBlock', () => {
+  it('renders highlighted code', () => {
+    const { container } = render(<CodeBlock code="const x = 1;" lang="javascript" />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('copies code when button clicked', () => {
+    const spy = core.copyToClipboard as unknown as vi.Mock;
+    render(<CodeBlock code="foo" lang="javascript" />);
+    screen.getByRole('button', { name: /copy code/i }).click();
+    expect(spy).toHaveBeenCalledWith('foo');
+  });
+});

--- a/nano-codeblock/packages/react/src/CodeBlock.tsx
+++ b/nano-codeblock/packages/react/src/CodeBlock.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { highlight, Theme, copyToClipboard, Token } from '@nano-codeblock/core';
+
+export interface CodeBlockProps {
+  code: string;
+  lang: string;
+  theme?: Theme;
+}
+
+export function CodeBlock({ code, lang, theme = Theme.dracula }: CodeBlockProps) {
+  const lines = React.useMemo<Token[][]>(() => highlight(code, lang), [code, lang]);
+
+  const handleCopy = React.useCallback(() => {
+    void copyToClipboard(code);
+  }, [code]);
+
+  return (
+    <pre className={`cb ${theme}`}> 
+      <button type="button" onClick={handleCopy} aria-label="Copy code" className="cb-copy">
+        Copy
+      </button>
+      <code>
+        {lines.map((line, i) => (
+          <span key={i} className="cb-line">
+            {line.map((token, j) => (
+              <span key={j} className={`cb-${token.type}`}>{token.content}</span>
+            ))}
+            {i < lines.length - 1 && '\n'}
+          </span>
+        ))}
+      </code>
+    </pre>
+  );
+}

--- a/nano-codeblock/packages/react/src/index.ts
+++ b/nano-codeblock/packages/react/src/index.ts
@@ -1,0 +1,2 @@
+export * from './CodeBlock';
+export { highlight, copyToClipboard, Theme } from '@nano-codeblock/core';

--- a/nano-codeblock/packages/react/tsconfig.json
+++ b/nano-codeblock/packages/react/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "jsx": "react-jsx",
+    "moduleResolution": "bundler"
+  },
+  "include": ["src"]
+}

--- a/nano-codeblock/packages/react/tsup.config.ts
+++ b/nano-codeblock/packages/react/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+});

--- a/nano-codeblock/packages/react/vitest.config.ts
+++ b/nano-codeblock/packages/react/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.test.tsx'],
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold React package
- configure tsup build
- implement `CodeBlock` component and exports
- add tests using React Testing Library
- document with a changeset

## Testing
- `pnpm lint --fix` *(fails: Cannot find module '@eslint/js')*
- `pnpm exec vitest run packages/react/src --run` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499d3075388329ac0de05d5581181c