### PR TITLE
feat(vue): add wrapper component

### DIFF
--- a/.changeset/vue-wrapper-component.md
+++ b/.changeset/vue-wrapper-component.md
@@ -1,0 +1,5 @@
+---
+"@nano-codeblock/vue": minor
+---
+
+Add Vue wrapper component with highlight and clipboard support.

--- a/nano-codeblock/packages/vue/package.json
+++ b/nano-codeblock/packages/vue/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@nano-codeblock/vue",
+  "version": "0.0.0",
+  "scripts": {
+    "build": "vite build -c ../../vite.vue.ts",
+    "test": "vitest"
+  },
+  "peerDependencies": {
+    "vue": "^3.0.0",
+    "@nano-codeblock/core": "workspace:*"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ]
+}

--- a/nano-codeblock/packages/vue/src/CodeBlock.test.ts
+++ b/nano-codeblock/packages/vue/src/CodeBlock.test.ts
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/vue';
+import { describe, it, expect, vi } from 'vitest';
+import CodeBlock from './CodeBlock.vue';
+import * as core from '@nano-codeblock/core';
+
+vi.mock('@nano-codeblock/core', async () => {
+  const actual = await vi.importActual<typeof core>('@nano-codeblock/core');
+  return { ...actual, copyToClipboard: vi.fn() };
+});
+
+describe('CodeBlock', () => {
+  it('renders highlighted code', () => {
+    const { container } = render(CodeBlock, { props: { code: 'const x = 1;', lang: 'javascript' } });
+    expect(container).toMatchSnapshot();
+  });
+
+  it('copies code when button clicked', async () => {
+    const spy = core.copyToClipboard as unknown as vi.Mock;
+    render(CodeBlock, { props: { code: 'foo', lang: 'javascript' } });
+    await screen.getByRole('button', { name: /copy code/i }).click();
+    expect(spy).toHaveBeenCalledWith('foo');
+  });
+});

--- a/nano-codeblock/packages/vue/src/CodeBlock.vue
+++ b/nano-codeblock/packages/vue/src/CodeBlock.vue
@@ -1,0 +1,24 @@
+<template>
+  <pre :class="`cb ${appliedTheme}`">
+    <button type="button" class="cb-copy" @click="handleCopy" aria-label="Copy code">Copy</button>
+    <code>
+      <span v-for="(line, i) in lines" :key="i" class="cb-line">
+        <span v-for="(token, j) in line" :key="j" :class="`cb-${token.type}`">{{ token.content }}</span><template v-if="i < lines.length - 1">\n</template>
+      </span>
+    </code>
+  </pre>
+</template>
+
+<script setup lang="ts">
+import { highlight, Theme, copyToClipboard, Token } from '@nano-codeblock/core';
+import { computed } from 'vue';
+
+const props = defineProps<{ code: string; lang: string; theme?: Theme }>();
+
+const lines = computed<Token[][]>(() => highlight(props.code, props.lang));
+const appliedTheme = computed(() => props.theme ?? Theme.dracula);
+
+function handleCopy() {
+  void copyToClipboard(props.code);
+}
+</script>

--- a/nano-codeblock/packages/vue/src/index.ts
+++ b/nano-codeblock/packages/vue/src/index.ts
@@ -1,0 +1,2 @@
+export { default as CodeBlock } from './CodeBlock.vue';
+export { highlight, copyToClipboard, Theme } from '@nano-codeblock/core';

--- a/nano-codeblock/packages/vue/tsconfig.json
+++ b/nano-codeblock/packages/vue/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "moduleResolution": "bundler"
+  },
+  "include": ["src"]
+}

--- a/nano-codeblock/packages/vue/vitest.config.ts
+++ b/nano-codeblock/packages/vue/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/vite.vue.ts
+++ b/vite.vue.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import dts from 'vite-plugin-dts';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [vue(), dts({ entryRoot: 'packages/vue/src', outDir: 'packages/vue/dist' })],
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'packages/vue/src/index.ts'),
+      formats: ['es', 'cjs'],
+      fileName: (format) => `index.${format === 'es' ? 'mjs' : 'js'}`,
+    },
+    rollupOptions: {
+      external: ['vue', '@nano-codeblock/core'],
+    },
+    outDir: 'packages/vue/dist',
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold Vue package
- add Vite build config
- implement Vue CodeBlock component
- export core utilities
- test rendering and clipboard copy

## Testing
- `pnpm lint --fix` *(fails: Cannot find module '@eslint/js')*
- `pnpm exec vitest run packages/core/src --run` *(fails: Command "vitest" not found)*
- `pnpm exec vitest run packages/vue/src --run` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bec4b7688329864c003c63310f22