### PR TITLE
Add svelte wrapper component

### DIFF
--- a/.changeset/svelte-wrapper-component.md
+++ b/.changeset/svelte-wrapper-component.md
@@ -1,0 +1,5 @@
+---
+"@nano-codeblock/svelte": minor
+---
+
+Add Svelte wrapper component with highlight and clipboard support.

--- a/nano-codeblock/packages/svelte/package.json
+++ b/nano-codeblock/packages/svelte/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@nano-codeblock/svelte",
+  "version": "0.0.0",
+  "scripts": {
+    "build": "vite build -c ../../vite.svelte.ts",
+    "test": "vitest"
+  },
+  "peerDependencies": {
+    "svelte": "^5.0.0",
+    "@nano-codeblock/core": "workspace:*"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ]
+}

--- a/nano-codeblock/packages/svelte/src/CodeBlock.svelte
+++ b/nano-codeblock/packages/svelte/src/CodeBlock.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { highlight, Theme, copyToClipboard, Token } from '@nano-codeblock/core';
+
+  export let code: string;
+  export let lang: string;
+  export let theme: Theme = Theme.dracula;
+
+  let lines: Token[][] = [];
+  $: lines = highlight(code, lang);
+
+  function handleCopy() {
+    void copyToClipboard(code);
+  }
+</script>
+
+<pre class={`cb ${theme}`}> 
+  <button type="button" class="cb-copy" on:click={handleCopy} aria-label="Copy code">Copy</button>
+  <code>
+    {#each lines as line, i}
+      <span class="cb-line">
+        {#each line as token}
+          <span class={`cb-${token.type}`}>{token.content}</span>
+        {/each}{#if i < lines.length - 1}
+        \n{/if}
+      </span>
+    {/each}
+  </code>
+</pre>

--- a/nano-codeblock/packages/svelte/src/CodeBlock.test.ts
+++ b/nano-codeblock/packages/svelte/src/CodeBlock.test.ts
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect, vi } from 'vitest';
+import CodeBlock from './CodeBlock.svelte';
+import * as core from '@nano-codeblock/core';
+
+vi.mock('@nano-codeblock/core', async () => {
+  const actual = await vi.importActual<typeof core>('@nano-codeblock/core');
+  return { ...actual, copyToClipboard: vi.fn() };
+});
+
+describe('CodeBlock', () => {
+  it('renders highlighted code', () => {
+    const { container } = render(CodeBlock, { props: { code: 'const x = 1;', lang: 'javascript' } });
+    expect(container).toMatchSnapshot();
+  });
+
+  it('copies code when button clicked', async () => {
+    const spy = core.copyToClipboard as unknown as vi.Mock;
+    render(CodeBlock, { props: { code: 'foo', lang: 'javascript' } });
+    await screen.getByRole('button', { name: /copy code/i }).click();
+    expect(spy).toHaveBeenCalledWith('foo');
+  });
+});

--- a/nano-codeblock/packages/svelte/src/index.ts
+++ b/nano-codeblock/packages/svelte/src/index.ts
@@ -1,0 +1,2 @@
+export { default as CodeBlock } from './CodeBlock.svelte';
+export { highlight, copyToClipboard, Theme } from '@nano-codeblock/core';

--- a/nano-codeblock/packages/svelte/tsconfig.json
+++ b/nano-codeblock/packages/svelte/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "moduleResolution": "bundler"
+  },
+  "include": ["src"]
+}

--- a/nano-codeblock/packages/svelte/vitest.config.ts
+++ b/nano-codeblock/packages/svelte/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+export default defineConfig({
+  plugins: [svelte()],
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/vite.svelte.ts
+++ b/vite.svelte.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import dts from 'vite-plugin-dts';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [svelte(), dts({ entryRoot: 'packages/svelte/src', outDir: 'packages/svelte/dist' })],
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'packages/svelte/src/index.ts'),
+      formats: ['es', 'cjs'],
+      fileName: (format) => `index.${format === 'es' ? 'mjs' : 'js'}`,
+    },
+    rollupOptions: {
+      external: ['svelte', '@nano-codeblock/core'],
+    },
+    outDir: 'packages/svelte/dist',
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold the `@nano-codeblock/svelte` package
- add Vite build config for Svelte
- implement Svelte `CodeBlock` component and tests
- provide changeset entry

## Testing
- `pnpm lint --fix` *(failed: Cannot find module '@eslint/js')*
- `pnpm exec vitest run packages/svelte/src --run` *(failed: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bfeab2f883299f7d864346e7ac62