### PR TITLE
Add Solid wrapper component

### DIFF
--- a/.changeset/solid-wrapper-component.md
+++ b/.changeset/solid-wrapper-component.md
@@ -1,0 +1,5 @@
+---
+"@nano-codeblock/solid": minor
+---
+
+Add Solid wrapper component with highlight and clipboard support.

--- a/nano-codeblock/packages/solid/package.json
+++ b/nano-codeblock/packages/solid/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@nano-codeblock/solid",
+  "version": "0.0.0",
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest"
+  },
+  "peerDependencies": {
+    "solid-js": "^1.0.0",
+    "@nano-codeblock/core": "workspace:*"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ]
+}

--- a/nano-codeblock/packages/solid/src/CodeBlock.test.tsx
+++ b/nano-codeblock/packages/solid/src/CodeBlock.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@codeblock/testing-library-solid';
+import { describe, it, expect, vi } from 'vitest';
+import { CodeBlock } from './CodeBlock';
+import * as core from '@nano-codeblock/core';
+
+vi.mock('@nano-codeblock/core', async () => {
+  const actual = await vi.importActual<typeof core>('@nano-codeblock/core');
+  return { ...actual, copyToClipboard: vi.fn() };
+});
+
+describe('CodeBlock', () => {
+  it('renders highlighted code', () => {
+    const { container } = render(() => <CodeBlock code="const x = 1;" lang="javascript" />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('copies code when button clicked', () => {
+    const spy = core.copyToClipboard as unknown as vi.Mock;
+    render(() => <CodeBlock code="foo" lang="javascript" />);
+    screen.getByRole('button', { name: /copy code/i }).click();
+    expect(spy).toHaveBeenCalledWith('foo');
+  });
+});

--- a/nano-codeblock/packages/solid/src/CodeBlock.tsx
+++ b/nano-codeblock/packages/solid/src/CodeBlock.tsx
@@ -1,0 +1,35 @@
+import { For, Component, createMemo, createSignal, onMount } from 'solid-js';
+import { highlight, Theme, copyToClipboard, Token } from '@nano-codeblock/core';
+
+export interface CodeBlockProps {
+  code: string;
+  lang: string;
+  theme?: Theme;
+}
+
+export const CodeBlock: Component<CodeBlockProps> = (props) => {
+  const lines = createMemo<Token[][]>(() => highlight(props.code, props.lang));
+  const [fadeIn, setFadeIn] = createSignal(false);
+
+  onMount(() => setFadeIn(true));
+
+  const handleCopy = () => {
+    void copyToClipboard(props.code);
+  };
+
+  return (
+    <pre class={`cb ${props.theme ?? Theme.dracula}`}>
+      <button type="button" onClick={handleCopy} aria-label="Copy code" class="cb-copy">
+        Copy
+      </button>
+      <code classList={{ 'cb-fade-in': fadeIn() }}>
+        <For each={lines()}>{(line, i) => (
+          <span class="cb-line">
+            <For each={line}>{(token) => <span class={`cb-${token.type}`}>{token.content}</span>}</For>
+            {i() < lines().length - 1 && '\n'}
+          </span>
+        )}</For>
+      </code>
+    </pre>
+  );
+};

--- a/nano-codeblock/packages/solid/src/index.ts
+++ b/nano-codeblock/packages/solid/src/index.ts
@@ -1,0 +1,2 @@
+export * from './CodeBlock';
+export { highlight, copyToClipboard, Theme } from '@nano-codeblock/core';

--- a/nano-codeblock/packages/solid/tsconfig.json
+++ b/nano-codeblock/packages/solid/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "moduleResolution": "bundler"
+  },
+  "include": ["src"]
+}

--- a/nano-codeblock/packages/solid/tsup.config.ts
+++ b/nano-codeblock/packages/solid/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+});

--- a/nano-codeblock/packages/solid/vitest.config.ts
+++ b/nano-codeblock/packages/solid/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.test.tsx'],
+  },
+});


### PR DESCRIPTION
## Summary
- solid package scaffold and build configuration
- Solid `CodeBlock` component with fade-in effect
- export Solid component and core utilities
- Solid test setup using testing-library-solid
- document new package in changeset

## Testing
- `pnpm lint --fix` *(fails: Cannot find module '@eslint/js')*
- `pnpm exec vitest run packages/solid/src --run` *(fails: Command "vitest" not found)*
- `pnpm exec vitest run packages/core/src --run` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bff6d5dc832993d08335701dc495