### PR TITLE
Add web package with code block element

### DIFF
--- a/.changeset/web-code-block-element.md
+++ b/.changeset/web-code-block-element.md
@@ -1,0 +1,5 @@
+---
+"@nano-codeblock/web": minor
+---
+
+Add web component built with Lit for syntax highlighting and clipboard support.

--- a/nano-codeblock/packages/web/package.json
+++ b/nano-codeblock/packages/web/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@nano-codeblock/web",
+  "version": "0.0.0",
+  "scripts": {
+    "build": "vite build -c ../../vite.web.ts",
+    "test": "vitest"
+  },
+  "peerDependencies": {
+    "lit": "^3.1.0",
+    "@nano-codeblock/core": "workspace:*"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ]
+}

--- a/nano-codeblock/packages/web/src/code-block.test.ts
+++ b/nano-codeblock/packages/web/src/code-block.test.ts
@@ -1,0 +1,34 @@
+/* eslint-env browser */
+/* eslint-disable no-undef */
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent } from '@testing-library/dom';
+import * as core from '@nano-codeblock/core';
+import { CodeBlock } from './code-block';
+
+vi.mock('@nano-codeblock/core', async () => {
+  const actual = await vi.importActual<typeof core>('@nano-codeblock/core');
+  return { ...actual, copyToClipboard: vi.fn() };
+});
+
+describe('CodeBlock', () => {
+  it('renders highlighted code', async () => {
+    const el = document.createElement('code-block') as CodeBlock;
+    el.code = 'const x = 1;';
+    el.lang = 'javascript';
+    document.body.appendChild(el);
+    await el.updateComplete;
+    expect(el.shadowRoot?.innerHTML).toMatchSnapshot();
+  });
+
+  it('copies code when button clicked', async () => {
+    const spy = core.copyToClipboard as unknown as vi.Mock;
+    const el = document.createElement('code-block') as CodeBlock;
+    el.code = 'foo';
+    el.lang = 'javascript';
+    document.body.appendChild(el);
+    await el.updateComplete;
+    const button = el.shadowRoot!.querySelector('button')!;
+    await fireEvent.click(button);
+    expect(spy).toHaveBeenCalledWith('foo');
+  });
+});

--- a/nano-codeblock/packages/web/src/code-block.ts
+++ b/nano-codeblock/packages/web/src/code-block.ts
@@ -1,0 +1,39 @@
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { highlight, copyToClipboard, Theme, Token } from '@nano-codeblock/core';
+
+@customElement('code-block')
+export class CodeBlock extends LitElement {
+  @property({ type: String }) code = '';
+  @property({ type: String }) lang = '';
+  @property({ type: String }) theme: Theme = Theme.dracula;
+
+  private get lines(): Token[][] {
+    return highlight(this.code, this.lang);
+  }
+
+  private handleCopy() {
+    void copyToClipboard(this.code);
+  }
+
+  render() {
+    const lines = this.lines;
+    return html`<pre class="cb ${this.theme}">
+      <button type="button" class="cb-copy" @click=${this
+      .handleCopy} aria-label="Copy code">Copy</button>
+      <code>
+        ${lines.map(
+      (line, i) =>
+        html`<span class="cb-line">
+          ${line.map((t) => html`<span class="cb-${t.type}">${t.content}</span>`)}${i <
+          lines.length - 1
+            ? '\n'
+            : ''}
+        </span>`
+    )}
+      </code>
+    </pre>`;
+  }
+}
+
+export type { Token } from '@nano-codeblock/core';

--- a/nano-codeblock/packages/web/src/index.ts
+++ b/nano-codeblock/packages/web/src/index.ts
@@ -1,0 +1,2 @@
+export * from './code-block';
+export { highlight, copyToClipboard, Theme } from '@nano-codeblock/core';

--- a/nano-codeblock/packages/web/tsconfig.json
+++ b/nano-codeblock/packages/web/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "moduleResolution": "bundler"
+  },
+  "include": ["src"]
+}

--- a/nano-codeblock/packages/web/vitest.config.ts
+++ b/nano-codeblock/packages/web/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/vite.web.ts
+++ b/vite.web.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import lit from '@vitejs/plugin-lit';
+import dts from 'vite-plugin-dts';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [lit(), dts({ entryRoot: 'packages/web/src', outDir: 'packages/web/dist' })],
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'packages/web/src/index.ts'),
+      formats: ['es', 'cjs'],
+      fileName: (format) => `index.${format === 'es' ? 'mjs' : 'js'}`,
+    },
+    rollupOptions: {
+      external: ['lit', '@nano-codeblock/core'],
+    },
+    outDir: 'packages/web/dist',
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold `@nano-codeblock/web` package
- create Lit-based `<code-block>` element
- set up Vite build config and Vitest config
- add unit tests and changeset

## Testing
- `pnpm lint --fix`
- `pnpm exec vitest run packages/core/src --run`
- `pnpm exec vitest run packages/web/src --run` *(fails: Failed to resolve entry for package "@nano-codeblock/core".)*

------
https://chatgpt.com/codex/tasks/task_e_6849bff86d38832982fb53c6a8fbb1e6