### PR TITLE
chore: setup repo lint config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  root: true,
+  extends: [
+    'eslint:recommended',
+    'plugin:import/recommended',
+    'plugin:prettier/recommended',
+  ],
+  parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+};

--- a/nano-codeblock/.husky/pre-commit
+++ b/nano-codeblock/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-pnpm lint --fix || true
+pnpm lint --fix

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  printWidth: 100,
+  trailingComma: 'es5',
+  singleQuote: true,
+};

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,9 +1,17 @@
 {
   "compilerOptions": {
-    "strict": true,
+    "target": "esnext",
+    "module": "esnext",
+    "lib": ["esnext", "dom"],
     "moduleResolution": "node16",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
     "paths": {
       "@nano-codeblock/*": ["packages/*/src"]
     }
-  }
+  },
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- update `tsconfig.base.json` with strict options and alias
- add ESLint and Prettier configs at repo root
- tweak Husky pre-commit hook to run lint

## Testing
- `pnpm lint --fix` *(fails: Cannot find module '@eslint/js')*
- `pnpm exec vitest run packages/core/src --run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c5d333608329ab16a3d8ff501334