### PR TITLE
Add UI package with tailwind config

### DIFF
--- a/.changeset/red-places-post.md
+++ b/.changeset/red-places-post.md
@@ -1,0 +1,5 @@
+---
+"packages/ui": minor
+---
+
+Add `@nano-codeblock/ui` with shared Header, Footer and Layout components and global Tailwind styles. Configure Tailwind at the repo root so apps and the UI package share the same config.

--- a/nano-codeblock/packages/ui/README.md
+++ b/nano-codeblock/packages/ui/README.md
@@ -1,0 +1,10 @@
+# @nano-codeblock/ui
+
+Shared React components and styles for NanoCodeBlock applications.
+
+## Usage
+
+```ts
+import { Layout } from '@nano-codeblock/ui';
+import '@nano-codeblock/ui/global.css';
+```

--- a/nano-codeblock/packages/ui/package.json
+++ b/nano-codeblock/packages/ui/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@nano-codeblock/ui",
+  "version": "0.0.0",
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "src/global.css"
+  ]
+}

--- a/nano-codeblock/packages/ui/src/Footer.tsx
+++ b/nano-codeblock/packages/ui/src/Footer.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export function Footer() {
+  return (
+    <footer className="bg-gray-800 p-4 text-white mt-auto text-sm text-center">
+      <p>&copy; {new Date().getFullYear()} NanoCodeBlock</p>
+    </footer>
+  );
+}

--- a/nano-codeblock/packages/ui/src/Header.tsx
+++ b/nano-codeblock/packages/ui/src/Header.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export function Header() {
+  return (
+    <header className="bg-gray-800 p-4 text-white">
+      <h1 className="text-xl font-bold">NanoCodeBlock</h1>
+    </header>
+  );
+}

--- a/nano-codeblock/packages/ui/src/Layout.tsx
+++ b/nano-codeblock/packages/ui/src/Layout.tsx
@@ -1,0 +1,14 @@
+import React, { PropsWithChildren } from 'react';
+import { Header } from './Header';
+import { Footer } from './Footer';
+import './global.css';
+
+export function Layout({ children }: PropsWithChildren) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <main className="flex-1">{children}</main>
+      <Footer />
+    </div>
+  );
+}

--- a/nano-codeblock/packages/ui/src/global.css
+++ b/nano-codeblock/packages/ui/src/global.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/nano-codeblock/packages/ui/src/index.ts
+++ b/nano-codeblock/packages/ui/src/index.ts
@@ -1,0 +1,3 @@
+export * from './Header';
+export * from './Footer';
+export * from './Layout';

--- a/nano-codeblock/packages/ui/tsconfig.json
+++ b/nano-codeblock/packages/ui/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "jsx": "react-jsx",
+    "moduleResolution": "bundler"
+  },
+  "include": ["src"]
+}

--- a/nano-codeblock/packages/ui/tsup.config.ts
+++ b/nano-codeblock/packages/ui/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './nano-codeblock/apps/**/*.{js,ts,jsx,tsx}',
+    './nano-codeblock/packages/ui/src/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add `@nano-codeblock/ui` package with shared components and global styles
- configure Tailwind to include apps and UI package

## Testing
- `pnpm lint --fix` *(fails: Cannot find module '@eslint/js')*
- `pnpm exec vitest run packages/core/src --run` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ce94189c8329b559c4c5b1cad862