### PR TITLE
feat(docs): add docs Next.js app

### DIFF
--- a/.changeset/friendly-dogs-listen.md
+++ b/.changeset/friendly-dogs-listen.md
@@ -1,0 +1,5 @@
+---
+"apps/docs": minor
+---
+
+Add Next.js 15 documentation app with Tailwind, MDX support and example pages.

--- a/nano-codeblock/apps/docs/README.md
+++ b/nano-codeblock/apps/docs/README.md
@@ -1,1 +1,3 @@
-# TODO
+# Docs App
+
+This Next.js application contains the documentation site for NanoCodeBlock.

--- a/nano-codeblock/apps/docs/app/docs/installation.mdx
+++ b/nano-codeblock/apps/docs/app/docs/installation.mdx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+# Installation
+
+Install the package via pnpm:
+
+```bash
+pnpm add @nano-codeblock/react
+```

--- a/nano-codeblock/apps/docs/app/docs/themes.mdx
+++ b/nano-codeblock/apps/docs/app/docs/themes.mdx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+# Themes
+
+NanoCodeBlock ships with several built-in themes such as `dracula` and `github`.
+
+Apply a theme using the `theme` prop on the React component.

--- a/nano-codeblock/apps/docs/app/globals.css
+++ b/nano-codeblock/apps/docs/app/globals.css
@@ -1,0 +1,5 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@import '@nano-codeblock/ui/src/global.css';

--- a/nano-codeblock/apps/docs/app/layout.tsx
+++ b/nano-codeblock/apps/docs/app/layout.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Layout } from '@nano-codeblock/ui';
+import './globals.css';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'NanoCodeBlock Docs'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <Layout>{children}</Layout>
+      </body>
+    </html>
+  );
+}

--- a/nano-codeblock/apps/docs/app/page.tsx
+++ b/nano-codeblock/apps/docs/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-bold mb-4">Welcome to NanoCodeBlock</h2>
+      <p>Explore the documentation to get started.</p>
+    </div>
+  );
+}

--- a/nano-codeblock/apps/docs/app/playground/page.tsx
+++ b/nano-codeblock/apps/docs/app/playground/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+import React from 'react';
+import { CodeBlock } from '@nano-codeblock/react';
+
+export default function Playground() {
+  const code = `console.log('Hello, world!')`;
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-bold mb-4">Playground</h2>
+      <CodeBlock code={code} lang="ts" />
+    </div>
+  );
+}

--- a/nano-codeblock/apps/docs/next-env.d.ts
+++ b/nano-codeblock/apps/docs/next-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+
+declare module '*.mdx' {
+  let MDXComponent: (props: any) => JSX.Element;
+  export default MDXComponent;
+}

--- a/nano-codeblock/apps/docs/next.config.mjs
+++ b/nano-codeblock/apps/docs/next.config.mjs
@@ -1,0 +1,9 @@
+import createMDX from '@next/mdx';
+
+const withMDX = createMDX();
+
+const nextConfig = {
+  experimental: { appDir: true }
+};
+
+export default withMDX(nextConfig);

--- a/nano-codeblock/apps/docs/package.json
+++ b/nano-codeblock/apps/docs/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@nano-codeblock/docs",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "15.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@nano-codeblock/ui": "workspace:*"
+  },
+  "devDependencies": {
+    "@next/mdx": "^1.7.1",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.4.1",
+    "typescript": "*"
+  }
+}

--- a/nano-codeblock/apps/docs/postcss.config.js
+++ b/nano-codeblock/apps/docs/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/nano-codeblock/apps/docs/tsconfig.json
+++ b/nano-codeblock/apps/docs/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "allowJs": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.mdx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js 15 app for docs
- hook up Tailwind via PostCSS
- use UI Layout and components
- enable MDX support
- add installation, themes, and playground pages
- document change in Changesets

## Testing
- `pnpm lint --fix` *(fails: Cannot find module '@eslint/js')*
- `pnpm exec vitest run packages/core/src --run` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d40804b8832996b4baef8e95bd01