### PR TITLE
feat(apps): add multi-framework examples

### DIFF
--- a/nano-codeblock/apps/examples/index.html
+++ b/nano-codeblock/apps/examples/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CodeBlock Examples</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/nano-codeblock/apps/examples/package.json
+++ b/nano-codeblock/apps/examples/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@nano-codeblock/examples",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0",
+    "framer-motion": "^11.0.0",
+    "@nano-codeblock/react": "workspace:*",
+    "@nano-codeblock/vue": "workspace:*",
+    "@nano-codeblock/svelte": "workspace:*",
+    "@nano-codeblock/solid": "workspace:*",
+    "@nano-codeblock/web": "workspace:*",
+    "@nano-codeblock/ui": "workspace:*"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.1.0",
+    "@vitejs/plugin-vue": "^5.0.2",
+    "@sveltejs/vite-plugin-svelte": "^3.0.1",
+    "vite-plugin-solid": "^2.7.0",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.32",
+    "autoprefixer": "^10.4.17",
+    "typescript": "*"
+  }
+}

--- a/nano-codeblock/apps/examples/postcss.config.js
+++ b/nano-codeblock/apps/examples/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/nano-codeblock/apps/examples/src/App.tsx
+++ b/nano-codeblock/apps/examples/src/App.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import { Layout } from '@nano-codeblock/ui';
+import ReactDemo from './routes/ReactDemo';
+import VueDemo from './routes/VueDemo';
+import SvelteDemo from './routes/SvelteDemo';
+import SolidDemo from './routes/SolidDemo';
+import WebDemo from './routes/WebDemo';
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Layout>
+        <nav className="bg-gray-100 p-4 space-x-4">
+          <Link to="/react">React</Link>
+          <Link to="/vue">Vue</Link>
+          <Link to="/svelte">Svelte</Link>
+          <Link to="/solid">Solid</Link>
+          <Link to="/web">Web</Link>
+        </nav>
+        <Routes>
+          <Route path="/" element={<ReactDemo />} />
+          <Route path="/react" element={<ReactDemo />} />
+          <Route path="/vue" element={<VueDemo />} />
+          <Route path="/svelte" element={<SvelteDemo />} />
+          <Route path="/solid" element={<SolidDemo />} />
+          <Route path="/web" element={<WebDemo />} />
+        </Routes>
+      </Layout>
+    </BrowserRouter>
+  );
+}

--- a/nano-codeblock/apps/examples/src/index.css
+++ b/nano-codeblock/apps/examples/src/index.css
@@ -1,0 +1,5 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@import '@nano-codeblock/ui/src/global.css';

--- a/nano-codeblock/apps/examples/src/main.tsx
+++ b/nano-codeblock/apps/examples/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/nano-codeblock/apps/examples/src/routes/ReactDemo.tsx
+++ b/nano-codeblock/apps/examples/src/routes/ReactDemo.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { CodeBlock } from '@nano-codeblock/react';
+import { motion } from 'framer-motion';
+
+export default function ReactDemo() {
+  return (
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+      <CodeBlock code={`console.log('React!')`} lang="javascript" />
+    </motion.div>
+  );
+}

--- a/nano-codeblock/apps/examples/src/routes/SolidDemo.tsx
+++ b/nano-codeblock/apps/examples/src/routes/SolidDemo.tsx
@@ -1,0 +1,14 @@
+import React, { useEffect, useRef } from 'react';
+import { render } from 'solid-js/web';
+import { CodeBlock } from '@nano-codeblock/solid';
+import { motion } from 'framer-motion';
+
+export default function SolidDemo() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    render(() => <CodeBlock code={`console.log('Solid!')`} lang="javascript" />, ref.current!);
+  }, []);
+
+  return <motion.div ref={ref} initial={{ opacity: 0 }} animate={{ opacity: 1 }} />;
+}

--- a/nano-codeblock/apps/examples/src/routes/SvelteDemo.tsx
+++ b/nano-codeblock/apps/examples/src/routes/SvelteDemo.tsx
@@ -1,0 +1,17 @@
+import React, { useEffect, useRef } from 'react';
+import SvelteCodeBlock from '@nano-codeblock/svelte';
+import { motion } from 'framer-motion';
+
+export default function SvelteDemo() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const component = new SvelteCodeBlock({
+      target: ref.current!,
+      props: { code: "console.log('Svelte!')", lang: 'javascript' }
+    });
+    return () => component.$destroy();
+  }, []);
+
+  return <motion.div ref={ref} initial={{ opacity: 0 }} animate={{ opacity: 1 }} />;
+}

--- a/nano-codeblock/apps/examples/src/routes/VueDemo.tsx
+++ b/nano-codeblock/apps/examples/src/routes/VueDemo.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect, useRef } from 'react';
+import { createApp, h } from 'vue';
+import { CodeBlock } from '@nano-codeblock/vue';
+import { motion } from 'framer-motion';
+
+export default function VueDemo() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const app = createApp({
+      render: () => h(CodeBlock, { code: "console.log('Vue!')", lang: 'javascript' })
+    });
+    app.mount(ref.current!);
+    return () => app.unmount();
+  }, []);
+
+  return <motion.div ref={ref} initial={{ opacity: 0 }} animate={{ opacity: 1 }} />;
+}

--- a/nano-codeblock/apps/examples/src/routes/WebDemo.tsx
+++ b/nano-codeblock/apps/examples/src/routes/WebDemo.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import '@nano-codeblock/web';
+import { motion } from 'framer-motion';
+
+export default function WebDemo() {
+  return (
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+      <code-block code="console.log('Web Component!')" lang="javascript"></code-block>
+    </motion.div>
+  );
+}

--- a/nano-codeblock/apps/examples/tailwind.config.js
+++ b/nano-codeblock/apps/examples/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  presets: [require('../../packages/ui/tailwind.preset.js')],
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx,vue,svelte,js,jsx}'
+  ]
+};

--- a/nano-codeblock/apps/examples/tsconfig.json
+++ b/nano-codeblock/apps/examples/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "vite.config.ts"],
+  "exclude": ["node_modules"]
+}

--- a/nano-codeblock/apps/examples/vite.config.ts
+++ b/nano-codeblock/apps/examples/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import vue from '@vitejs/plugin-vue';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import solid from 'vite-plugin-solid';
+
+export default defineConfig({
+  plugins: [react(), vue(), svelte(), solid()]
+});

--- a/nano-codeblock/packages/ui/tailwind.preset.js
+++ b/nano-codeblock/packages/ui/tailwind.preset.js
@@ -1,0 +1,7 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,8 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  presets: [require('./nano-codeblock/packages/ui/tailwind.preset.js')],
   content: [
     './nano-codeblock/apps/**/*.{js,ts,jsx,tsx}',
-    './nano-codeblock/packages/ui/src/**/*.{js,ts,jsx,tsx}',
-  ],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
+    './nano-codeblock/packages/ui/src/**/*.{js,ts,jsx,tsx}'
+  ]
 };


### PR DESCRIPTION
## Summary
- configure `apps/examples` using React + Vite
- share Tailwind preset from `packages/ui`
- demonstrate React, Vue, Svelte, Solid and Web Component versions of `<CodeBlock>`
- add simple animations with Framer Motion

## Testing
- `pnpm lint --fix` *(fails: Cannot find module '@eslint/js')*
- `pnpm exec vitest run packages/core/src --run` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d58b9f5483299ea8f5d8cddbf65d