### PR TITLE
Add CI and release workflows

### DIFF
--- a/.changeset/ci-workflow.md
+++ b/.changeset/ci-workflow.md
@@ -1,0 +1,5 @@
+---
+"@nano-codeblock/core": patch
+---
+
+Add GitHub Actions workflows for build, test, and release using Changesets.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: nano-codeblock
+      - name: Build
+        run: pnpm build
+        working-directory: nano-codeblock
+      - name: Test
+        run: pnpm test
+        working-directory: nano-codeblock

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'pnpm'
+          registry-url: https://registry.npmjs.org/
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: nano-codeblock
+      - name: Create Release Pull Request or Publish
+        uses: changesets/action@v1
+        with:
+          publish: pnpm publish -r --access public
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- set up CI to build and test on GitHub Actions
- add release workflow powered by Changesets
- record CI workflow addition in Changesets

## Testing
- `pnpm lint --fix` *(failed: Cannot find module '@eslint/js')*
- `pnpm exec vitest run packages/core/src --run` *(failed: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d6ff7ca48329887b5cfe5eafa494