### PR TITLE
Update Tailwind scan paths

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   presets: [require('./nano-codeblock/packages/ui/tailwind.preset.js')],
   content: [
-    './nano-codeblock/apps/**/*.{js,ts,jsx,tsx}',
+    './nano-codeblock/apps/**/*.{js,ts,jsx,tsx,mdx,vue,svelte}',
     './nano-codeblock/packages/ui/src/**/*.{js,ts,jsx,tsx}'
   ]
 };


### PR DESCRIPTION
## Summary
- extend Tailwind CSS scan paths to include MDX, Vue, and Svelte files

## Testing
- `pnpm lint --fix` *(failed: Cannot find module '@eslint/js')*
- `pnpm exec vitest run packages/core/src --run` *(failed: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849de947ea08329811e322bfecf11cd