### PR TITLE
feat(wrappers): add default fade-in

### DIFF
--- a/.changeset/wrappers-fade-in.md
+++ b/.changeset/wrappers-fade-in.md
@@ -1,0 +1,8 @@
+---
+"@nano-codeblock/react": minor
+"@nano-codeblock/vue": minor
+"@nano-codeblock/svelte": minor
+"@nano-codeblock/web": minor
+---
+
+Add default fade-in animation to all wrapper components.

--- a/nano-codeblock/packages/react/src/CodeBlock.test.tsx
+++ b/nano-codeblock/packages/react/src/CodeBlock.test.tsx
@@ -11,6 +11,8 @@ vi.mock('@nano-codeblock/core', async () => {
 describe('CodeBlock', () => {
   it('renders highlighted code', () => {
     const { container } = render(<CodeBlock code="const x = 1;" lang="javascript" />);
+    const code = container.querySelector('code');
+    expect(code).toHaveClass('cb-fade-in');
     expect(container).toMatchSnapshot();
   });
 

--- a/nano-codeblock/packages/react/src/CodeBlock.tsx
+++ b/nano-codeblock/packages/react/src/CodeBlock.tsx
@@ -9,6 +9,11 @@ export interface CodeBlockProps {
 
 export function CodeBlock({ code, lang, theme = Theme.dracula }: CodeBlockProps) {
   const lines = React.useMemo<Token[][]>(() => highlight(code, lang), [code, lang]);
+  const [fade, setFade] = React.useState(false);
+
+  React.useEffect(() => {
+    setFade(true);
+  }, []);
 
   const handleCopy = React.useCallback(() => {
     void copyToClipboard(code);
@@ -19,7 +24,7 @@ export function CodeBlock({ code, lang, theme = Theme.dracula }: CodeBlockProps)
       <button type="button" onClick={handleCopy} aria-label="Copy code" className="cb-copy">
         Copy
       </button>
-      <code>
+      <code className={fade ? 'cb-fade-in' : ''}>
         {lines.map((line, i) => (
           <span key={i} className="cb-line">
             {line.map((token, j) => (

--- a/nano-codeblock/packages/svelte/src/CodeBlock.svelte
+++ b/nano-codeblock/packages/svelte/src/CodeBlock.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { highlight, Theme, copyToClipboard, Token } from '@nano-codeblock/core';
+  import { onMount } from 'svelte';
 
   export let code: string;
   export let lang: string;
@@ -7,6 +8,11 @@
 
   let lines: Token[][] = [];
   $: lines = highlight(code, lang);
+  let fade = false;
+
+  onMount(() => {
+    fade = true;
+  });
 
   function handleCopy() {
     void copyToClipboard(code);
@@ -15,7 +21,7 @@
 
 <pre class={`cb ${theme}`}> 
   <button type="button" class="cb-copy" on:click={handleCopy} aria-label="Copy code">Copy</button>
-  <code>
+  <code class:cb-fade-in={fade}>
     {#each lines as line, i}
       <span class="cb-line">
         {#each line as token}

--- a/nano-codeblock/packages/svelte/src/CodeBlock.test.ts
+++ b/nano-codeblock/packages/svelte/src/CodeBlock.test.ts
@@ -13,6 +13,8 @@ describe('CodeBlock', () => {
     const { container } = render(CodeBlock, {
       props: { code: 'const x = 1;', lang: 'javascript' },
     });
+    const code = container.querySelector('code');
+    expect(code).toHaveClass('cb-fade-in');
     expect(container).toMatchSnapshot();
   });
 

--- a/nano-codeblock/packages/vue/src/CodeBlock.test.ts
+++ b/nano-codeblock/packages/vue/src/CodeBlock.test.ts
@@ -13,6 +13,8 @@ describe('CodeBlock', () => {
     const { container } = render(CodeBlock, {
       props: { code: 'const x = 1;', lang: 'javascript' },
     });
+    const code = container.querySelector('code');
+    expect(code).toHaveClass('cb-fade-in');
     expect(container).toMatchSnapshot();
   });
 

--- a/nano-codeblock/packages/vue/src/CodeBlock.vue
+++ b/nano-codeblock/packages/vue/src/CodeBlock.vue
@@ -1,7 +1,7 @@
 <template>
   <pre :class="`cb ${appliedTheme}`">
     <button type="button" class="cb-copy" @click="handleCopy" aria-label="Copy code">Copy</button>
-    <code>
+    <code ref="codeEl">
       <span v-for="(line, i) in lines" :key="i" class="cb-line">
         <span v-for="(token, j) in line" :key="j" :class="`cb-${token.type}`">{{ token.content }}</span><template v-if="i < lines.length - 1">\n</template>
       </span>
@@ -11,12 +11,17 @@
 
 <script setup lang="ts">
 import { highlight, Theme, copyToClipboard, Token } from '@nano-codeblock/core';
-import { computed } from 'vue';
+import { computed, ref, onMounted } from 'vue';
 
 const props = defineProps<{ code: string; lang: string; theme?: Theme }>();
 
 const lines = computed<Token[][]>(() => highlight(props.code, props.lang));
 const appliedTheme = computed(() => props.theme ?? Theme.dracula);
+const codeEl = ref<HTMLElement | null>(null);
+
+onMounted(() => {
+  codeEl.value?.classList.add('cb-fade-in');
+});
 
 function handleCopy() {
   void copyToClipboard(props.code);

--- a/nano-codeblock/packages/web/src/code-block.test.ts
+++ b/nano-codeblock/packages/web/src/code-block.test.ts
@@ -17,6 +17,8 @@ describe('CodeBlock', () => {
     el.lang = 'javascript';
     document.body.appendChild(el);
     await el.updateComplete;
+    const code = el.shadowRoot!.querySelector('code');
+    expect(code).toHaveClass('cb-fade-in');
     expect(el.shadowRoot?.innerHTML).toMatchSnapshot();
   });
 

--- a/nano-codeblock/packages/web/src/code-block.ts
+++ b/nano-codeblock/packages/web/src/code-block.ts
@@ -7,6 +7,7 @@ export class CodeBlock extends LitElement {
   @property({ type: String }) code = '';
   @property({ type: String }) lang = '';
   @property({ type: String }) theme: Theme = Theme.dracula;
+  @property({ type: Boolean }) private fade = false;
 
   private get lines(): Token[][] {
     return highlight(this.code, this.lang);
@@ -16,12 +17,17 @@ export class CodeBlock extends LitElement {
     void copyToClipboard(this.code);
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    this.fade = true;
+  }
+
   render() {
     const lines = this.lines;
     return html`<pre class="cb ${this.theme}">
       <button type="button" class="cb-copy" @click=${this
       .handleCopy} aria-label="Copy code">Copy</button>
-      <code>
+      <code class=${this.fade ? 'cb-fade-in' : ''}>
         ${lines.map(
       (line, i) =>
         html`<span class="cb-line">


### PR DESCRIPTION
## Summary
- add fade-in default for wrapper components
- test the fade state
- note failing `pnpm lint --fix` due to missing deps

## Testing
- `pnpm lint --fix` *(fails: 'HTMLDivElement' not defined)*
- `pnpm exec vitest run packages/core/src --run`

------
https://chatgpt.com/codex/tasks/task_e_6849dea7fdc88329989c076b077845f8