### PR TITLE
docs: expand readmes with contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # NanoCodeBlock
-Cross‑Framework Code Block Component
+
+Cross-framework code block component.
+
+The monorepo is contained in `nano-codeblock/` and uses a standard `apps` and `packages` layout.
+
+## Goal
+
+Provide a reusable code block component that works across React, Vue, and Svelte projects.
+
+## Features
+
+- Syntax highlighting with your choice of themes
+- Copy-to-clipboard button
+- Light and dark mode support
+- Works in both server and client environments
+
+## Setup
+
+```sh
+cd nano-codeblock
+pnpm install
+```
+
+## Development
+
+```sh
+pnpm dev    # start apps in watch mode
+pnpm build  # build all packages
+pnpm test   # run unit tests
+```
+
+## Contributing
+
+1. Read the repository root [AGENTS.md](AGENTS.md) for workflow expectations.
+2. Create a branch and run `pnpm lint --fix` and `pnpm test` before opening a PR.
+3. Use conventional commit messages when committing changes.
+
+See [AGENTS.md](AGENTS.md) for full contribution guidelines.

--- a/nano-codeblock/README.md
+++ b/nano-codeblock/README.md
@@ -1,84 +1,32 @@
-# Turborepo starter
+# NanoCodeBlock Workspace
 
-This Turborepo starter is maintained by the Turborepo core team.
+This directory houses the Turborepo workspace for the cross-framework code block component.
+Apps live in `apps/` and reusable packages in `packages/`.
 
-## Using this example
+## Goal
 
-Run the following command:
+Ship a drop-in code block component that can be consumed by multiple frontend frameworks.
+
+## Features
+
+- Themeable syntax highlighting
+- Copy button
+- Works with React, Vue, and Svelte
+
+## Installation
 
 ```sh
-npx create-turbo@latest
+pnpm install
 ```
 
-## What's inside?
+## Development Commands
 
-This Turborepo includes the following packages/apps:
-
-### Apps and Packages
-
-- `docs`: a [Next.js](https://nextjs.org/) app
-- `web`: another [Next.js](https://nextjs.org/) app
-- `@repo/ui`: a stub React component library shared by both `web` and `docs` applications
-- `@repo/eslint-config`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
-- `@repo/typescript-config`: `tsconfig.json`s used throughout the monorepo
-
-Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).
-
-### Utilities
-
-This Turborepo has some additional tools already setup for you:
-
-- [TypeScript](https://www.typescriptlang.org/) for static type checking
-- [ESLint](https://eslint.org/) for code linting
-- [Prettier](https://prettier.io) for code formatting
-
-### Build
-
-To build all apps and packages, run the following command:
-
-```
-cd my-turborepo
-pnpm build
+```sh
+pnpm dev     # run all apps in watch mode
+pnpm build   # build packages and apps
+pnpm test    # run unit tests
 ```
 
-### Develop
+## Contributing
 
-To develop all apps and packages, run the following command:
-
-```
-cd my-turborepo
-pnpm dev
-```
-
-### Remote Caching
-
-> [!TIP]
-> Vercel Remote Cache is free for all plans. Get started today at [vercel.com](https://vercel.com/signup?/signup?utm_source=remote-cache-sdk&utm_campaign=free_remote_cache).
-
-Turborepo can use a technique known as [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
-
-By default, Turborepo will cache locally. To enable Remote Caching you will need an account with Vercel. If you don't have an account you can [create one](https://vercel.com/signup?utm_source=turborepo-examples), then enter the following commands:
-
-```
-cd my-turborepo
-npx turbo login
-```
-
-This will authenticate the Turborepo CLI with your [Vercel account](https://vercel.com/docs/concepts/personal-accounts/overview).
-
-Next, you can link your Turborepo to your Remote Cache by running the following command from the root of your Turborepo:
-
-```
-npx turbo link
-```
-
-## Useful Links
-
-Learn more about the power of Turborepo:
-
-- [Tasks](https://turborepo.com/docs/crafting-your-repository/running-tasks)
-- [Caching](https://turborepo.com/docs/crafting-your-repository/caching)
-- [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching)
-- [Filtering](https://turborepo.com/docs/crafting-your-repository/running-tasks#using-filters)
-- [Configuration Options](https://turborepo.com/docs/reference/configuration)
-- [CLI Usage](https://turborepo.com/docs/reference/command-line-reference)
+See the root [AGENTS.md](../AGENTS.md) for workflow details. Run `pnpm lint --fix` and `pnpm test` before submitting a pull request.


### PR DESCRIPTION
## Summary
- document goal and features in repository README
- outline contribution steps in both READMEs

## Testing
- `pnpm lint --fix` *(fails: Cannot find module '@eslint/js')*
- `pnpm exec vitest run packages/core/src --run` *(fails: command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849deb5bc8c8329b46607eea7ee45dc